### PR TITLE
[FIX] library: avoids to set books inactive

### DIFF
--- a/library/models/book.py
+++ b/library/models/book.py
@@ -21,6 +21,10 @@ class BookCopy(models.Model):
 
     book_id = fields.Many2one('product.product', string="Book", domain=[('is_book', "=", True)], required=True, ondelete="cascade", delegate=True)
     reference = fields.Char(required=True, string="Ref")
+    # "Override" active field to avoid to modify the one from Books model
+    # (because of delegate), so, when a rental is marked as lost, only the copy
+    # become inactive, not the book itself.
+    active = fields.Boolean(default=True)
 
     rental_ids = fields.One2many('library.rental', 'copy_id', string='Rentals')
     book_state = fields.Selection([('available', 'Available'), ('rented', 'Rented'), ('lost', 'Lost')], default="available")


### PR DESCRIPTION
We add a active field in BookCopy model to avoid to modify the one from
Books model.
It's because otherwise, when a rental is defined as lost, the book
itself is marked as inactive and result is the book and all its copies
are archived.