### PR TITLE
[FIX] estate: add missing category to manifest

### DIFF
--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -3,6 +3,7 @@
 
 {
     "name": "Real Estate",
+    "category": 'Real Estate/Brokerage',
     "depends": [
         "base",
         "web",


### PR DESCRIPTION
Adds category to the manifest so that the module category id is correctly generated and now matches the Getting started/Advanced B: ACL and Record Rules documentation.

Signed-off-by: Claire Bretton (clbr) <clbr@odoo.com>