### PR TITLE
[IMP] Real Estate: add security and visibility changes

### DIFF
--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -4,12 +4,14 @@
 {
     "name": "Real Estate",
     "license": "LGPL-3",
+    "category": "Real Estate",
     "depends": [
         "base",
         "web",
     ],
     "data": [
         "security/ir.model.access.csv",
+        "security/security.xml",
         "views/estate_property_offer_views.xml",
         "views/estate_property_tag_views.xml",
         "views/estate_property_type_views.xml",

--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -3,6 +3,7 @@
 
 {
     "name": "Real Estate",
+    "license": "LGPL-3",
     "depends": [
         "base",
         "web",

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -14,6 +14,7 @@ class EstateProperty(models.Model):
     _name = "estate.property"
     _description = "Real Estate Property"
     _order = "id desc"
+    _check_company_auto = True
     _sql_constraints = [
         ("check_expected_price", "CHECK(expected_price > 0)", "The expected price must be strictly positive"),
         ("check_selling_price", "CHECK(selling_price >= 0)", "The offer price must be positive"),
@@ -67,7 +68,7 @@ class EstateProperty(models.Model):
 
     # Relational
     property_type_id = fields.Many2one("estate.property.type", string="Property Type")
-    user_id = fields.Many2one("res.users", string="Salesman", default=lambda self: self.env.user)
+    user_id = fields.Many2one("res.users", string="Salesman")
     buyer_id = fields.Many2one("res.partner", string="Buyer", readonly=True, copy=False)
     tag_ids = fields.Many2many("estate.property.tag", string="Tags")
     offer_ids = fields.One2many("estate.property.offer", "property_id", string="Offers")
@@ -79,6 +80,11 @@ class EstateProperty(models.Model):
         help="Total area computed by summing the living area and the garden area",
     )
     best_price = fields.Float("Best Offer", compute="_compute_best_price", help="Best offer received")
+
+    # Multi-Company
+    company_id = fields.Many2one(
+        'res.company', required=True, default = lambda self: self.env.company
+    )
 
     # ---------------------------------------- Compute methods ------------------------------------
 

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -83,7 +83,7 @@ class EstateProperty(models.Model):
 
     # Multi-Company
     company_id = fields.Many2one(
-        'res.company', required=True, default = lambda self: self.env.company
+        'res.company', required=True, default=lambda self: self.env.company
     )
 
     # ---------------------------------------- Compute methods ------------------------------------

--- a/estate/security/ir.model.access.csv
+++ b/estate/security/ir.model.access.csv
@@ -1,5 +1,13 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_estate_property,access.estate.property,estate.model_estate_property,base.group_user,1,1,1,1
-access_estate_property_offer,access.estate.property.offer,estate.model_estate_property_offer,base.group_user,1,1,1,1
-access_estate_property_tag,access.estate.property.tag,estate.model_estate_property_tag,base.group_user,1,1,1,1
-access_estate_property_type,access.estate.property.type,estate.model_estate_property_type,base.group_user,1,1,1,1
+access_estate_property,access_estate_property,model_estate_property,base.group_user,0,0,0,0
+access_estate_property_type,access_estate_property_type,model_estate_property_type,base.group_user,0,0,0,0
+access_estate_property_tag,access_estate_property_tag,model_estate_property_tag,base.group_user,0,0,0,0
+access_estate_property_offer,access_estate_property_offer,model_estate_property_offer,base.group_user,0,0,0,0
+access_estate_property_manager,access.estate.property,estate.model_estate_property,estate.estate_group_manager,1,1,1,1
+access_estate_property_offer_manager,access.estate.property.offer,estate.model_estate_property_offer,estate.estate_group_manager,1,1,1,1
+access_estate_property_tag_manager,access.estate.property.tag,estate.model_estate_property_tag,estate.estate_group_manager,1,1,1,1
+access_estate_property_type_manager,access.estate.property.type,estate.model_estate_property_type,estate.estate_group_manager,1,1,1,1
+access_estate_property_agent,access.estate.property,estate.model_estate_property,estate.estate_group_user,1,1,1,0
+access_estate_property_offer_agent,access.estate.property.offer,estate.model_estate_property_offer,estate.estate_group_user,1,0,0,0
+access_estate_property_tag_agent,access.estate.property.tag,estate.model_estate_property_tag,estate.estate_group_user,1,0,0,0
+access_estate_property_type_agent,access.estate.property.type,estate.model_estate_property_type,estate.estate_group_user,1,0,0,0

--- a/estate/security/security.xml
+++ b/estate/security/security.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="estate_group_user" model="res.groups">
+        <field name="name">Agent</field>
+        <field name="category_id" ref="base.module_category_real_estate_brokerage"/>
+    </record>
+
+    <record id="estate_group_manager" model="res.groups">
+        <field name="name">Manager</field>
+        <field name="category_id" ref="base.module_category_real_estate_brokerage"/>
+        <field name="implied_ids" eval="[([ref('estate_group_user')])]"/>
+    </record>
+
+    <record id="estate_agent_property_limit" model="ir.rule">
+        <field name="name">limit estate agent access to own properties or unclaimed properties</field>
+        <field name="model_id" ref="model_estate_property"/>
+        <!-- <field name="perm_read" eval="False"/> -->
+        <field name="groups" eval="[Command.link(ref('estate.estate_group_user'))]"/>
+        <field name="domain_force">[
+            '|', ('user_id', '=', user.id),
+                 ('user_id', '=', False)
+        ]</field>
+    </record>
+
+    <record id="estate_manager_rule" model="ir.rule">
+        <field name="name">Estate manager rule</field>
+        <field name="model_id" ref="model_estate_property"/>
+        <field name="groups" eval="[Command.link(ref('estate.estate_group_manager'))]"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+    </record>
+
+    <record id="multi_company_rule" model="ir.rule">
+        <field name="name">multi company rule</field>
+        <field name="model_id" ref="model_estate_property"/>
+        <field name="groups" eval="[Command.link(ref('estate.estate_group_user')), Command.link(ref('estate.estate_group_manager'))]"/>
+        <field name="domain_force">[('company_id','in', company_ids)]</field>
+    </record>
+
+</odoo>

--- a/estate/security/security.xml
+++ b/estate/security/security.xml
@@ -15,26 +15,15 @@
     <record id="estate_agent_property_limit" model="ir.rule">
         <field name="name">limit estate agent access to own properties or unclaimed properties</field>
         <field name="model_id" ref="model_estate_property"/>
-        <!-- <field name="perm_read" eval="False"/> -->
-        <field name="groups" eval="[Command.link(ref('estate.estate_group_user'))]"/>
-        <field name="domain_force">[
-            '|', ('user_id', '=', user.id),
-                 ('user_id', '=', False)
-        ]</field>
+        <field name="groups" eval="[(4, ref('estate.estate_group_user'))]"/>
+        <field name="domain_force">[('company_id', 'in', company_ids), '|', ('user_id', '=', False), ('user_id', '=', user.id)]</field>
     </record>
 
     <record id="estate_manager_rule" model="ir.rule">
         <field name="name">Estate manager rule</field>
         <field name="model_id" ref="model_estate_property"/>
-        <field name="groups" eval="[Command.link(ref('estate.estate_group_manager'))]"/>
+        <field name="groups" eval="[(4, ref('estate.estate_group_manager'))]"/>
         <field name="domain_force">[(1, '=', 1)]</field>
-    </record>
-
-    <record id="multi_company_rule" model="ir.rule">
-        <field name="name">multi company rule</field>
-        <field name="model_id" ref="model_estate_property"/>
-        <field name="groups" eval="[Command.link(ref('estate.estate_group_user')), Command.link(ref('estate.estate_group_manager'))]"/>
-        <field name="domain_force">[('company_id','in', company_ids)]</field>
     </record>
 
 </odoo>

--- a/estate/views/estate_menus.xml
+++ b/estate/views/estate_menus.xml
@@ -5,7 +5,7 @@
         <menuitem id="estate_advertisement_menu" name="Advertisements" sequence="5">
             <menuitem id="estate_property_menu_action" action="estate_property_action" sequence="5"/>
         </menuitem>
-        <menuitem id="estate_settings_menu" name="Settings" sequence="10">
+        <menuitem id="estate_settings_menu" name="Settings" sequence="10" groups="estate_group_manager">
             <menuitem id="estate_property_type_menu_action" action="estate_property_type_action" sequence="5"/>
             <menuitem id="estate_property_tag_menu_action" action="estate_property_tag_action" sequence="10"/>
         </menuitem>

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -21,6 +21,7 @@
                     </div>
                     <group>
                         <group>
+                            <field name="company_id"/>
                             <field name="property_type_id" options="{'no_create': True, 'no_edit': True}"/>
                             <field name="postcode"/>
                             <field name="date_availability"/>
@@ -48,7 +49,8 @@
                             </group>
                         </page>
                         <page string="Offers">
-                            <field name="offer_ids" attrs="{'readonly': [('state', 'in', ('offer_accepted', 'sold', 'canceled'))]}"/>
+                            <field name="offer_ids" />
+                            <!-- attrs="{'readonly': [('state', 'in', ('offer_accepted', 'sold', 'canceled'))]}" -->
                         </page>
                         <page string="Other Info">
                             <group>
@@ -79,6 +81,7 @@
                 <field name="selling_price"/>
                 <field name="date_availability" optional="hide"/>
                 <field name="state" invisible="1"/>
+                <field name="company_id" groups="base.group_multi_company"/>
             </tree>
         </field>
     </record>

--- a/estate_account/__manifest__.py
+++ b/estate_account/__manifest__.py
@@ -2,6 +2,7 @@
 
 {
     "name": "Real Estate Accounting",
+    "license": "LGPL-3",
     "depends": [
         "estate",
         "account",

--- a/estate_account/models/estate_property.py
+++ b/estate_account/models/estate_property.py
@@ -17,6 +17,9 @@ class EstateProperty(models.Model):
         # Another way to get the journal:
         # journal = self.env["account.move"].with_context(default_move_type="out_invoice")._get_default_journal()
         for prop in self:
+            if not self.env['estate.property'].check_access_rights('write') or not prop.check_access_rule('write'):
+                return res
+            print(" reached ".center(100, '='))
             self.env["account.move"].create(
                 {
                     "partner_id": prop.buyer_id.id,


### PR DESCRIPTION
restrict estate_agent access and give access to all to managers
don't show settings menu to agents, only to managers 
setup multi-company
end of chapter B